### PR TITLE
feat: 게시글 삭제 api 완

### DIFF
--- a/(backend)/ootd/application/usecases/DeleteUseCase.ts
+++ b/(backend)/ootd/application/usecases/DeleteUseCase.ts
@@ -1,0 +1,20 @@
+import SbBoardRepository from '../../infrastructure/repositories/SbBoardRepositories';
+
+class DeleteUseCase {
+  private boardRepository: SbBoardRepository;
+
+  constructor(boardRepository: SbBoardRepository) {
+    this.boardRepository = boardRepository;
+  }
+
+  async execute(id: string): Promise<void> {
+    try {
+      await this.boardRepository.delete(id);
+    } catch (error) {
+      console.error('게시글 삭제 실패:', error);
+      throw error;
+    }
+  }
+}
+
+export default DeleteUseCase;

--- a/(backend)/ootd/infrastructure/repositories/SbBoardRepositories.ts
+++ b/(backend)/ootd/infrastructure/repositories/SbBoardRepositories.ts
@@ -25,15 +25,11 @@ class SbBoardRepository implements IBoardRepository {
 
   // 게시글 생성
   async create(board: Omit<Board, 'id' | 'date_created'>, img_url?: string[]): Promise<Board> {
-    const { data, error } = await this.supabase.from('post').insert([board]).select().single();
-    if (error) {
-      console.error('Supabase error:', error);
-      throw new Error(`Failed to create board: ${error.message}`);
-    }
+    const { data } = await this.supabase.from('post').insert([board]).select().single();
     if (!data) {
-      throw new Error('No data returned from insert operation');
+      throw new Error('데이터 반환 없음');
     }
-    console.log('Successfully created board:', data);
+    console.log('성공적으로 게시글 생성:', data);
 
     // 2. 이미지들 저장 (있는 경우)
     if (img_url && Array.isArray(img_url) && img_url.length > 0) {
@@ -64,9 +60,6 @@ class SbBoardRepository implements IBoardRepository {
 
   //게시글 수정(글 내용만 수정)
   async update(id: string, updateData: Partial<Board>): Promise<void> {
-    if (!updateData.text) {
-      throw new Error('text 필드만 수정할 수 있습니다.');
-    }
     const { error } = await this.supabase
       .from('post')
       .update({ text: updateData.text })
@@ -85,9 +78,30 @@ class SbBoardRepository implements IBoardRepository {
     }
   }
 
+  /*게시글 삭제 */
   async delete(id: string): Promise<void> {
-    const { error } = await this.supabase.from('post').delete().eq('id', id);
-    if (error) throw error;
+    try {
+      // 1. 게시글 이미지 삭제
+      const { error: photoError } = await this.supabase.from('photo').delete().eq('post_id', id);
+
+      if (photoError) {
+        console.error('이미지 삭제 실패:', photoError);
+        throw new Error(`이미지 삭제 실패: ${photoError.message}`);
+      }
+
+      // 2. 게시글 삭제
+      const { error: postError } = await this.supabase.from('post').delete().eq('id', id);
+
+      if (postError) {
+        console.error('게시글 삭제 실패:', postError);
+        throw new Error(`게시글 삭제 실패: ${postError.message}`);
+      }
+
+      console.log('삭제 성공:', id);
+    } catch (error) {
+      console.error('삭제 실패:', error);
+      throw error;
+    }
   }
 }
 

--- a/app/api/ootd/route.ts
+++ b/app/api/ootd/route.ts
@@ -4,6 +4,7 @@ import SbBoardRepository from '@/(backend)/ootd/infrastructure/repositories/SbBo
 import { supabase } from '@/utils/supabase/supabaseClient';
 import { NextRequest, NextResponse } from 'next/server';
 import UpdateUseCase from '@/(backend)/ootd/application/usecases/UpdateUseCase';
+import DeleteUseCase from '@/(backend)/ootd/application/usecases/DeleteUseCase';
 
 /* 게시글 작성 */
 export async function POST(req: NextRequest) {
@@ -75,6 +76,32 @@ export async function PUT(req: NextRequest) {
     console.error('Error updating board:', error);
     return NextResponse.json(
       { message: '게시글 수정 실패', error: 'UPDATE_ERROR' },
+      { status: 500 },
+    );
+  }
+}
+
+/* 게시글 삭제 */
+export async function DELETE(req: NextRequest) {
+  try {
+    const supabaseClient = supabase;
+    const repository = new SbBoardRepository(supabaseClient);
+    const deleteUseCase = new DeleteUseCase(repository);
+
+    const { searchParams } = new URL(req.url);
+    const id = searchParams.get('id');
+
+    if (!id) {
+      return NextResponse.json({ message: '게시글 ID는 필수입니다.' }, { status: 400 });
+    }
+
+    await deleteUseCase.execute(id);
+
+    return NextResponse.json({ message: '게시글이 삭제되었습니다.' }, { status: 200 });
+  } catch (error) {
+    console.error('Error deleting board:', error);
+    return NextResponse.json(
+      { message: '게시글 삭제 실패', error: 'DELETE_ERROR' },
       { status: 500 },
     );
   }


### PR DESCRIPTION
## 🔥 PR 제목  
> 게시글 삭제 api 완


## ✨ 작업 내용
- 사용자가 작성한 게시글 삭제 기능

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 🚀 테스트 방법  
### yarn run dev
### SupaBase에서 Post 테이블에 게시글 id 확인
### http://localhost:3000/api/ootd?id={원하는 id}를 넣어서 send

{
###     "message": "게시글이 삭제되었습니다."
}
### 잘 수행 됬으면 이런 메세지를 받게 됨


## 📸 스크린샷 / 시연 (선택)  
> ### Before
<img width="1333" height="347" alt="image" src="https://github.com/user-attachments/assets/8ce34bec-8053-4cbc-a3d4-33322188dc68" />

### After
<img width="1333" height="264" alt="image" src="https://github.com/user-attachments/assets/f374432e-a21a-42f1-b29c-f77e3ef7fb82" />

## 🙏 리뷰어에게 한마디  
잘 부탁 드리겠습니다~
