### PR TITLE
fix: ootd 페이지 재접속 시 이전 화면 리랜더링 수정 및 온도별 필터 후 인기순 정렬 전체 인기순 정렬로 변하는 에러 수정

### DIFF
--- a/(backend)/ootd/infrastructure/repositories/SbBoardRepositories.ts
+++ b/(backend)/ootd/infrastructure/repositories/SbBoardRepositories.ts
@@ -249,12 +249,13 @@ class SbBoardRepository implements IBoardRepository {
         query = query.limit(limit);
       }
 
-      // 인기순 정렬: 최신순 정렬(order by date_created)을 적용하지 않음
       if (sort === 'popular') {
-        // limit, offset 없이 전체 데이터 조회
-        const { data, error } = await this.buildPostQuery()
+        let popQuery = this.buildPostQuery()
           .gte('date_created', startDate)
           .lt('date_created', endDate);
+        if (!isNaN(minNum)) popQuery = popQuery.gte('feels_like', minNum);
+        if (!isNaN(maxNum)) popQuery = popQuery.lte('feels_like', maxNum);
+        const { data, error } = await popQuery;
         if (error) throw error;
         const postsWithCounts = this.transformBoardDataArray(data || []);
         // 좋아요 내림차순, 같으면 최신순
@@ -263,7 +264,6 @@ class SbBoardRepository implements IBoardRepository {
           if (likeDiff !== 0) return likeDiff;
           return new Date(b.date_created).getTime() - new Date(a.date_created).getTime();
         });
-        // 페이지네이션 적용
         return sorted.slice(offset ?? 0, (offset ?? 0) + (limit ?? 10));
       }
 

--- a/app/(anon)/ootd/components/OotdPostList.tsx
+++ b/app/(anon)/ootd/components/OotdPostList.tsx
@@ -7,11 +7,11 @@ import Comment from '@/public/assets/icons/chat.svg';
 import Like from '@/public/assets/icons/heart.svg';
 import { useRouter } from 'next/navigation';
 import InfiniteScroll from 'react-infinite-scroll-component';
-import { useSeasonStore } from '@/stores/seasonStore';
 import { usePathname } from 'next/navigation';
-import { useTempFilterStore } from '@/stores/tempFilterStore';
-import { useSortStore } from '@/stores/sortStore';
 import Postfloating from './Postfloating';
+import TempFlt from './TempFlt/TempFlt';
+import SortPost from './SortPost/SortPost';
+import OotdSeasonDropdown from './SeasonFlt/OotdSeasonDropdown';
 
 function getCurrentSeason() {
   const month = new Date().getMonth() + 1;
@@ -25,32 +25,27 @@ const LIMIT = 6;
 
 const OotdPostList = () => {
   const router = useRouter();
-  const selectedSeason = useSeasonStore((state) => state.selectedSeason);
   const pathname = usePathname();
-  const setSelectedSeason = useSeasonStore((state) => state.setSelectedSeason);
+  const [selectedSeason, setSelectedSeason] = useState(getCurrentSeason());
+  const [selectedTemp, setSelectedTemp] = useState('전체');
+  const [sort, setSort] = useState('recent');
   const [posts, setPosts] = useState<BoardWithUser[]>([]);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
-  const selectedTemp = useTempFilterStore((state) => state.selectedTemp);
-  const sort = useSortStore((state) => state.sort);
 
-  // 온도 구간 파싱 함수 (모든 형식 지원)
   function parseTempRange(tempRange: string) {
     if (tempRange === '전체') return {};
 
-    // "0-4" 형식 처리
     if (tempRange.includes('-') && !tempRange.includes('~')) {
       const [min, max] = tempRange.split('-').map(Number);
       return { min, max };
     }
 
-    // "~(-6)" 형식 처리
     if (tempRange.startsWith('~(') && tempRange.endsWith(')')) {
       const max = Number(tempRange.replace('~(', '').replace(')', ''));
       return { max };
     }
 
-    // "-5~ -1" 형식 처리 (공백 제거)
     if (tempRange.includes('~')) {
       const [minStr, maxStr] = tempRange.split('~');
       const min = minStr.trim() !== '' ? Number(minStr.trim()) : undefined;
@@ -85,7 +80,7 @@ const OotdPostList = () => {
     if (pathname === '/ootd') {
       setSelectedSeason(getCurrentSeason());
     }
-  }, [pathname, setSelectedSeason]);
+  }, [pathname]);
 
   useEffect(() => {
     setPosts([]);
@@ -102,6 +97,17 @@ const OotdPostList = () => {
 
   return (
     <>
+      <div className="flex">
+        <OotdSeasonDropdown selectedSeason={selectedSeason} setSelectedSeason={setSelectedSeason} />
+        <TempFlt
+          selectedSeason={selectedSeason}
+          selectedTemp={selectedTemp}
+          setSelectedTemp={setSelectedTemp}
+        />
+      </div>
+      <div className="flex justify-end">
+        <SortPost sort={sort} setSort={setSort} />
+      </div>
       <InfiniteScroll
         dataLength={posts.length}
         next={handleLoadMore}

--- a/app/(anon)/ootd/components/SeasonFlt/OotdSeasonDropdown.tsx
+++ b/app/(anon)/ootd/components/SeasonFlt/OotdSeasonDropdown.tsx
@@ -12,15 +12,18 @@ function getCurrentSeason() {
 }
 
 interface OotdSeasonDropdownProps {
-  onSeasonChange?: (season: string) => void;
+  selectedSeason: string;
+  setSelectedSeason: (season: string) => void;
 }
 
-const OotdSeasonDropdown = ({ onSeasonChange }: OotdSeasonDropdownProps) => {
-  const { isOpen, setIsOpen, selected, setSelected, ref } = useDropdown(getCurrentSeason());
+const OotdSeasonDropdown = ({ selectedSeason, setSelectedSeason }: OotdSeasonDropdownProps) => {
+  const { isOpen, setIsOpen, selected, setSelected, ref } = useDropdown(
+    selectedSeason || getCurrentSeason(),
+  );
 
   const handleSeasonChange = (newSeason: string) => {
     setSelected(newSeason);
-    onSeasonChange?.(newSeason);
+    setSelectedSeason(newSeason);
   };
 
   return (
@@ -30,6 +33,7 @@ const OotdSeasonDropdown = ({ onSeasonChange }: OotdSeasonDropdownProps) => {
       isOpen={isOpen}
       setIsOpen={setIsOpen}
       ref={ref}
+      setSelectedSeason={setSelectedSeason}
     />
   );
 };

--- a/app/(anon)/ootd/components/SeasonFlt/SeasonFilter.tsx
+++ b/app/(anon)/ootd/components/SeasonFlt/SeasonFilter.tsx
@@ -1,7 +1,6 @@
 'use client';
 import React from 'react';
 import Arrow from '@/public/assets/icons/arrow.svg';
-import { useSeasonStore } from '@/stores/seasonStore';
 
 interface DropdownProps<T> {
   selected: T;
@@ -9,6 +8,7 @@ interface DropdownProps<T> {
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
   ref: React.RefObject<HTMLDivElement | null>;
+  setSelectedSeason: (season: string) => void;
 }
 
 function SeasonFilter<T extends string | number>({
@@ -17,9 +17,8 @@ function SeasonFilter<T extends string | number>({
   isOpen,
   setIsOpen,
   ref,
+  setSelectedSeason,
 }: DropdownProps<T>) {
-  const { setSelectedSeason } = useSeasonStore();
-
   return (
     <div>
       <div ref={ref} className="relative inline-block pl-[20px] pt-[32px]">

--- a/app/(anon)/ootd/components/SortPost/SortPost.tsx
+++ b/app/(anon)/ootd/components/SortPost/SortPost.tsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import Arrow from '@/public/assets/icons/arrow.svg';
 import useDropdown from '@/hooks/useDropdown';
-import { useSortStore } from '@/stores/sortStore';
 
 const SORT_OPTIONS = ['최신순', '인기순'];
 const SORT_MAP: Record<string, 'recent' | 'popular'> = {
@@ -10,9 +9,15 @@ const SORT_MAP: Record<string, 'recent' | 'popular'> = {
   인기순: 'popular',
 };
 
-const SortPost = () => {
-  const { isOpen, setIsOpen, selected, setSelected, ref } = useDropdown(SORT_OPTIONS[0]);
-  const setSort = useSortStore((state) => state.setSort);
+interface SortPostProps {
+  sort: string;
+  setSort: (sort: string) => void;
+}
+
+const SortPost = ({ sort, setSort }: SortPostProps) => {
+  const selectedOption =
+    Object.keys(SORT_MAP).find((key) => SORT_MAP[key] === sort) || SORT_OPTIONS[0];
+  const { isOpen, setIsOpen, selected, setSelected, ref } = useDropdown(selectedOption);
 
   return (
     <div ref={ref} className=" relative inline-block mr-[20px]">

--- a/app/(anon)/ootd/components/TempFlt/TempFlt.tsx
+++ b/app/(anon)/ootd/components/TempFlt/TempFlt.tsx
@@ -2,15 +2,19 @@
 import React, { useEffect } from 'react';
 import Arrow from '@/public/assets/icons/arrow.svg';
 import useDropdown from '@/hooks/useDropdown';
-import { useSeasonStore } from '@/stores/seasonStore';
 import getTempOptionsBySeason from '@/utils/ootd/getTempOptionsBySeason';
-import { useTempFilterStore } from '@/stores/tempFilterStore';
 
-const TempFlt = () => {
-  const selectedSeason = useSeasonStore((state) => state.selectedSeason);
+interface TempFltProps {
+  selectedSeason: string;
+  selectedTemp: string;
+  setSelectedTemp: (temp: string) => void;
+}
+
+const TempFlt = ({ selectedSeason, selectedTemp, setSelectedTemp }: TempFltProps) => {
   const TEMP_RANGES = getTempOptionsBySeason(selectedSeason);
-  const { isOpen, setIsOpen, selected, setSelected, ref } = useDropdown(TEMP_RANGES[0]);
-  const setSelectedTemp = useTempFilterStore((state) => state.setSelectedTemp);
+  const { isOpen, setIsOpen, selected, setSelected, ref } = useDropdown(
+    selectedTemp || TEMP_RANGES[0],
+  );
 
   useEffect(() => {
     if (!TEMP_RANGES.includes(selected)) {

--- a/app/(anon)/ootd/page.tsx
+++ b/app/(anon)/ootd/page.tsx
@@ -1,19 +1,9 @@
 'use client';
-import OotdSeasonDropdown from './components/SeasonFlt/OotdSeasonDropdown';
-import TempFlt from './components/TempFlt/TempFlt';
-import SortPost from './components/SortPost/SortPost';
 import OotdPostList from './components/OotdPostList';
 
 const Ootd = () => {
   return (
     <div>
-      <div className="flex">
-        <OotdSeasonDropdown />
-        <TempFlt />
-      </div>
-      <div className="flex justify-end">
-        <SortPost />
-      </div>
       <OotdPostList />
     </div>
   );


### PR DESCRIPTION
## 🔥 PR 제목  
> fix: ootd 페이지 재접속 시 이전 화면 리랜더링 수정 및 온도별 필터 후 인기순 정렬 전체 인기순 정렬로 변하는 에러 수정


## ✨ 작업 내용
- OOTD 페이지 필터 이용 후 페이지 전환 후 재접속 시 전에 사용된 화면이 리랜더링 되어 사용자에게 불편한을 주는 에러 수정
zustand로 사용하여 필터들을 구현 하였으며, 상태 관리로 인해 상태가 남아 리랜더링 발생 이 문제를 useState로 상태를 변경하여 상태가 남아 이전 리랜더링을 없앰

- 온도별 필터 사용하여 게시글 조회 후 인기순 정렬 클릭 시 이전 필터의 게시글 중에서 인기순 필터가 되어야 하는데 전체 게시글 인기순으로 변경되는 사항 수정


## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 🚀 테스트 방법  
> yarn run dev
OOTD 메인 페이지 테스트 진행

## 📸 스크린샷 / 시연 (선택)  
> OOTD 메인 페이지 테스트 진행


## 🙏 리뷰어에게 한마디  
고생들 많으셨습니다.
