### PR TITLE
feat: 로그아웃, 회원탈퇴 연결

### DIFF
--- a/app/(anon)/home/HomeClient.tsx
+++ b/app/(anon)/home/HomeClient.tsx
@@ -113,6 +113,14 @@ export default function HomeClient() {
     window.location.href = kakaoAuthUrl;
   };
 
+  const handlePostClick = (postId: number) => {
+    if (isJwtAuthenticated) {
+      router.push(`/ootd/${postId}`);
+    } else {
+      handleOpenModal();
+    }
+  };
+
   return (
     <>
       {showLoginModal && (
@@ -133,11 +141,11 @@ export default function HomeClient() {
       <div className="text-black text-[22px] font-semibold mb-[16px] mt-[6px] ml-4 mr-4">
         OOTD, 이건 어때요?
       </div>
-      <HomeCarousel slides={carouselSlides} />
+      <HomeCarousel slides={carouselSlides} onSlideClick={handlePostClick} />
       <div className="text-black text-[22px] font-semibold mb-[16px] mt-[6px] ml-4 mr-4 whitespace-pre-line leading-[28px] mt-[24px]">
         {`${feels_like}℃, 오늘 뭐 입지? \n 인기 코디 모아보기`}
       </div>
-      <TopPosts posts={topPosts} />
+      <TopPosts posts={topPosts} onPostClick={handlePostClick} />
       <div className="mt-[32px] pb-[50px] px-[20px]">
         <MoreButton content="더 보러 가기" onClick={() => router.push('/ootd')} />
       </div>

--- a/app/(anon)/home/components/HomeCarousel.tsx
+++ b/app/(anon)/home/components/HomeCarousel.tsx
@@ -4,7 +4,6 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import { Autoplay, Navigation } from 'swiper/modules';
-import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
 interface Slide {
@@ -13,10 +12,10 @@ interface Slide {
 }
 interface HomeCarouselProps {
   slides: Slide[];
+  onSlideClick: (postId: number) => void;
 }
 
-const HomeCarousel = ({ slides }: HomeCarouselProps) => {
-  const router = useRouter();
+const HomeCarousel = ({ slides, onSlideClick }: HomeCarouselProps) => {
   if (slides.length === 0) {
     return (
       <div className="ml-4 mr-4">
@@ -59,8 +58,8 @@ const HomeCarousel = ({ slides }: HomeCarouselProps) => {
                 alt={`slide-${slide.id}`}
                 fill
                 className="object-cover cursor-pointer"
-                onClick={() => router.push(`/ootd/${slide.id}`)}
-                priority
+                onClick={() => onSlideClick(slide.id)}
+                priority={idx === 0}
               />
             </div>
           </SwiperSlide>

--- a/app/(anon)/home/components/TopPosts.tsx
+++ b/app/(anon)/home/components/TopPosts.tsx
@@ -1,15 +1,14 @@
 'use client';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 interface Posts {
   id: number;
   img: string;
 }
 interface TopPostsProps {
   posts: Posts[];
+  onPostClick: (postId: number) => void;
 }
-const TopPosts = ({ posts }: TopPostsProps) => {
-  const router = useRouter();
+const TopPosts = ({ posts, onPostClick }: TopPostsProps) => {
   // 최대 8개만 보여줌
   const top8 = posts.slice(0, 8);
 
@@ -20,7 +19,7 @@ const TopPosts = ({ posts }: TopPostsProps) => {
           <div
             key={post.id}
             className="w-full aspect-square relative overflow-hidden rounded-[4px]"
-            onClick={() => router.push(`/ootd/${post.id}`)}
+            onClick={() => onPostClick(post.id)}
           >
             <Image
               src={post.img}
@@ -28,7 +27,6 @@ const TopPosts = ({ posts }: TopPostsProps) => {
               fill
               className="object-cover"
               sizes="50vw, 25vw"
-              priority
             />
           </div>
         ))}

--- a/app/(anon)/my/components/PhotoGrid.tsx
+++ b/app/(anon)/my/components/PhotoGrid.tsx
@@ -147,13 +147,14 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({ type }) => {
 
       {/* End of content */}
       {!hasMore && photos.length > 0 && (
-        <div className="text-center py-4 text-gray-500">No more photos to load</div>
+        // <div className="text-center py-4 text-gray-500">No more photos to load</div>
+        <div></div>
       )}
 
       {/* Empty state */}
       {!loading && photos.length === 0 && (
         <div className="text-center py-8 text-gray-500">
-          {type === 'my' ? 'No photos yet' : 'No liked photos yet'}
+          {type === 'my' ? '아직 업로드한 ootd가 없어요.' : '아직 좋아요한 ootd가 없어요.'}
         </div>
       )}
     </div>

--- a/app/(anon)/my/page.tsx
+++ b/app/(anon)/my/page.tsx
@@ -4,11 +4,41 @@ import { useEffect, useState } from 'react';
 import api from '@/utils/axiosInstance';
 import ToggleBar from './components/ToggleBar';
 import ProfileEditHeader from './components/ProfileEditHeader';
+import { useRouter } from 'next/navigation';
+import { UnenrollModalContainer } from '@/app/components';
 
 //my
 export default function My() {
   const [userName, setUserName] = useState<string | null>(null);
   const [profilePicture, setProfilePicture] = useState<string | null>(null);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const router = useRouter();
+
+  const handleProfileUpdate = (newProfilePicture: string | null) => {
+    setProfilePicture(newProfilePicture);
+  };
+
+  const handleDeleteModal = () => {
+    setIsDeleteModalOpen(true);
+  };
+
+  const handleLogout = async () => {
+    try {
+      await api.get('/auth/logout');
+      router.push('/');
+    } catch (error) {
+      console.error('로그아웃 중 오류가 발생했습니다.', error);
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await api.delete('/users/me');
+      router.push('/');
+    } catch (error) {
+      console.error('회원탈퇴 중 오류가 발생했습니다.', error);
+    }
+  };
 
   useEffect(() => {
     const fetchProfileInfo = async () => {
@@ -28,10 +58,6 @@ export default function My() {
     fetchProfileInfo();
   }, []);
 
-  const handleProfileUpdate = (newProfilePicture: string | null) => {
-    setProfilePicture(newProfilePicture);
-  };
-
   return (
     <div className="w-full h-[100vh]">
       <ProfileEditHeader
@@ -40,7 +66,29 @@ export default function My() {
         onProfileUpdate={handleProfileUpdate}
       />
       <ToggleBar />
-      <span className="flex w-full h-[80px]"></span>
+      <div className="flex justify-center bg-white">
+        <button
+          onClick={handleLogout}
+          className="text-[#6A71E5] text-[15px] font-normal underline cursor-pointer"
+        >
+          로그아웃
+        </button>
+      </div>
+      <div className="flex justify-center bg-white pt-4">
+        <button
+          onClick={handleDeleteModal}
+          className="text-[#6A71E5] text-[15px] font-normal underline cursor-pointer"
+        >
+          회원탈퇴
+        </button>
+      </div>
+      <span className="flex w-full h-[200px] bg-white"></span>
+      {isDeleteModalOpen && (
+        <UnenrollModalContainer
+          onUnenroll={handleDelete}
+          onClose={() => setIsDeleteModalOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/app/(anon)/page.tsx
+++ b/app/(anon)/page.tsx
@@ -4,7 +4,13 @@ import Home from './home/HomeClient';
 export default function Page() {
   return (
     <>
-      <Suspense fallback={<div>로딩 중...</div>}>
+      <Suspense
+        fallback={
+          <div className="w-full h-screen flex justify-center items-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--b400)]"></div>
+          </div>
+        }
+      >
         <Home />
       </Suspense>
     </>

--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -75,9 +75,10 @@ export async function DELETE() {
 
     const result = await userDeleteUseCase.execute(token);
 
-    // 쿠키 삭제
+    // 쿠키 삭제 (access token과 refresh token 모두)
     const response = NextResponse.json(result);
     response.cookies.set('token', '', { maxAge: 0, path: '/' });
+    response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' });
 
     return response;
   } catch (error) {

--- a/app/components/UnenrollModalContainer.tsx
+++ b/app/components/UnenrollModalContainer.tsx
@@ -6,14 +6,15 @@ import { Button } from './Button';
 
 interface UnenrollModalContainerProps {
   onUnenroll: () => void;
+  onClose: () => void;
 }
 
-const UnenrollModalContainer: React.FC<UnenrollModalContainerProps> = ({ onUnenroll }) => {
+const UnenrollModalContainer: React.FC<UnenrollModalContainerProps> = ({ onUnenroll, onClose }) => {
   return (
     <Modal
       text="모든 게시물과 정보가 삭제됩니다. 정말로 탈퇴하시겠어요?"
       btn={<Button content="탈퇴하기" big={false} onClick={onUnenroll} />}
-      onClose={() => console.log('Unenroll modal closed')}
+      onClose={onClose}
     />
   );
 };


### PR DESCRIPTION
## 🔥 PR 제목  
> feat: 로그아웃, 회원탈퇴 연결


## ✨ 작업 내용
- 마이페이지에서 로그아웃과 회원탈퇴 버튼을 생성 후 api 연결하였습니다.
- 회원탈퇴 후 리프레시 토큰이 삭제되지 않아 접근되지 않아야 하는 페이지에 접근되고 있어 회원탈퇴 api도 수정하였습니다. 


## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 🚀 테스트 방법  
> 마이페이지에서 로그아웃과 회원탈퇴를 진행합니다.**(회원탈퇴 주의해야 하는 게 현재 대희님이 만들어주신 더미데이터가 삭제될 수 있어요.)**


## 📸 스크린샷 / 시연 (선택)  
> 
<<로그아웃>>
https://github.com/user-attachments/assets/1e33449b-2ac1-4789-bb69-0220cc8b7bfe

<<회원탈퇴>>
https://github.com/user-attachments/assets/fb77cb12-24a9-4303-a001-75a75f4c8fac


## 🙏 리뷰어에게 한마디  
> 화이팅입니다~
