### PR TITLE
style: 인풋, 버튼 스타일 수정

### DIFF
--- a/app/(anon)/ootd/[id]/components/Input.tsx
+++ b/app/(anon)/ootd/[id]/components/Input.tsx
@@ -11,14 +11,14 @@ interface InputProps {
 const Input: React.FC<InputProps> = ({ value, onChange, onSend, inputRef }) => {
   const isEmpty = !value.trim();
   return (
-    <div className="max-w-[430px] w-full mx-auto fixed bottom-0 left-1/2 -translate-x-1/2 bg-white z-50 pb-[36px]">
+    <div className="max-w-[430px] w-full mx-auto fixed bottom-0 left-1/2 -translate-x-1/2 bg-white z-200 pb-[36px]">
       {/* 상단 구분선 */}
       <div className="h-px bg-gray-100 mb-4 " />
       <div className="flex items-center h-11 ml-4 mr-4">
         <input
           type="text"
           ref={inputRef}
-          className="flex-1 h-full bg-[#f1f0f0] rounded-l-xl rounded-r-xl px-4 py-2 text-[15px] text-black placeholder-gray-400 border-none outline-none focus:ring-0"
+          className="flex-1 h-full bg-[#f1f0f0] rounded-l-xl rounded-r-xl px-4 py-2 text-[16px] text-black placeholder-gray-400 border-none outline-none focus:ring-0"
           placeholder={'댓글을 입력해주세요.'}
           value={value}
           onChange={onChange}

--- a/app/(anon)/ootd/write/page.tsx
+++ b/app/(anon)/ootd/write/page.tsx
@@ -99,7 +99,7 @@ export default function Write() {
           {content.length} / 500자 이내
         </div>
       </section>
-      <div className="fixed bottom-0 left-1/2 -translate-x-1/2  flex justify-center z-10 bg-white py-[20px]">
+      <div className="w-full fixed bottom-0 left-1/2 -translate-x-1/2  flex justify-center z-10 bg-white py-[20px]">
         <Button content="등록하기" disabled={isButtonDisabled} type="submit" />
       </div>
     </form>


### PR DESCRIPTION
## 🔥 PR 제목  
> style: 인풋, 버튼 스타일 수정


## ✨ 작업 내용
- 인풋창 포커스 시 iOS의 사파리의 경우 자동 확대되는 현상이 발생합니다.
- 인풋의 폰트가 16px 이상이면 확대가 되지 않는다고 하여 폰트 크기를 수정하였습니다. 
- 폰트 크기를 수정하지 않고 그대로 가려면 인풋창의 크기를 scale()로 줄여서 실제로는 16px처럼 안보이게 하는 방법이 있습니다. 
- width, height, padding, border-radius 등등 모든 속성이 함께 줄어들기 때문에 기존에 적용하고 있던 스타일 속성들이 있다면 모두 줄어드는 비율만큼 더 크게 설정해야 하기 때문에 지금은 폰트 크기를 키워서 문제를 해결하도록 하겠습니다.
- 작성하기 페이지의 버튼 스타일은 너비를 수정하였습니다.


## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.



## 🙏 리뷰어에게 한마디  
> 화이팅!!
